### PR TITLE
Seperate training for bottom and prior model

### DIFF
--- a/pixelsnail.py
+++ b/pixelsnail.py
@@ -246,11 +246,11 @@ class HierarchicalPixelSNAIL(pl.LightningModule):
         self.criterion = nn.NLLLoss()
 
     def forward(self, top_code, bot_code):
-        top_code = self.top(top_code)
         condition = F.interpolate(top_code, scale_factor=2)
         for module in self.condition_stack:
             condition = condition + module(condition)
         bot_code = self.bottom(torch.cat((bot_code, condition), dim=1))
+        top_code = self.top(top_code)
         return top_code, bot_code
 
     def configure_optimizers(self):


### PR DESCRIPTION
I've been working on this model, and the pixel snail training code didn't converge.

I found out that the problem was that the original code was training the top and bottom prior models simultaneously, whereas the paper trained the two models in seperate.

Changing the order of the top and bottom generation can ensure that the gradients of the two models flow seperately and helps the model converge.